### PR TITLE
Improve logging: reduce verbosity for general messages and prevent cr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to
 
 ## [Unreleased]
 
+Lower the general logging level and prevent crash logs by using shutdown error
+reasons.
+
 ## [1.0.1] - 2025-02-26
 
 Cleanup TLS options in debug log

--- a/src/jarl_connection.erl
+++ b/src/jarl_connection.erl
@@ -397,7 +397,7 @@ handle_common(info, {'DOWN', _, process, Pid, Reason}, StateName,
         {shutdown, R} -> {shutdown, R};
         R -> {shutdown, R}
     end,
-    {stop, SafeReason, Data};
+    {stop, SafeReason, connection_closed(Data, SafeReason)};
 handle_common(info, {gun_up, Pid, http} = Info, StateName,
               #data{gun_pid = GunPid}) ->
     ?JARL_DEBUG("Ignoring unexpected gun_up message"

--- a/test/jarl_test_server.erl
+++ b/test/jarl_test_server.erl
@@ -21,6 +21,7 @@
 -export([receive_jsonrpc_result/0]).
 -export([receive_jsonrpc_error/0]).
 -export([send_text/1]).
+-export([send_frame/1]).
 -export([send_jsonrpc_notification/2]).
 -export([send_jsonrpc_request/3]).
 -export([send_jsonrpc_result/2]).
@@ -145,7 +146,10 @@ check_jsonrpc(Msg) ->
     end.
 
 send_text(Msg) ->
-    ?MODULE ! {?FUNCTION_NAME, Msg}.
+    send_frame({text, Msg}).
+
+send_frame(Frame) ->
+    ?MODULE ! {?FUNCTION_NAME, Frame}.
 
 send_jsonrpc_notification(Method, Params) ->
     Map = #{jsonrpc => <<"2.0">>,
@@ -216,8 +220,8 @@ websocket_info({listen, Pid}, State) ->
 websocket_info(send_ping, State) ->
     schedule_ping(State),
     {[ping], State};
-websocket_info({send_text, Msg}, State) ->
-    {[{text, Msg}], State};
+websocket_info({send_frame, Frame}, State) ->
+    {[Frame], State};
 websocket_info(close_websocket, State) ->
     {[close], State};
 websocket_info(Info, State) ->


### PR DESCRIPTION
…ash logs

 - Lower generla log level
 - Use shutdown error reasons to prevent crash logs
 - Better gun error handling
 - Better connection cleanup