### PR TITLE
Fix encoding of structured error data

### DIFF
--- a/src/jarl_jsonrpc.erl
+++ b/src/jarl_jsonrpc.erl
@@ -31,6 +31,11 @@
 -define(is_id(ID),
     (is_binary(ID) orelse is_integer(ID))
 ).
+-define(is_json_value(Value),
+    (is_atom(Value) orelse is_boolean(Value) orelse is_integer(Value)
+     orelse is_float(Value) orelse is_binary(Value) orelse is_list(Value)
+     orelse is_map(Value))
+).
 
 
 %--- API -----------------------------------------------------------------------
@@ -142,7 +147,7 @@ pack({ErrorTag, Code, Message, undefined, ID})
 pack({ErrorTag, Code, Message, Data, ID})
   when ErrorTag =:= error orelse ErrorTag =:= decoding_error, is_integer(Code),
        Message =:= undefined orelse is_binary(Message), ?is_id(ID),
-       is_binary(Data) ->
+       ?is_json_value(Data) ->
     #{?V, error => #{code => Code, message => Message, data => Data}, id => ID};
 pack(Message) ->
     erlang:error({badarg, Message}).

--- a/test/jarl_SUITE.erl
+++ b/test/jarl_SUITE.erl
@@ -188,6 +188,12 @@ basic_server_request_test(Config) ->
     ?assertConnRequest(Conn, [bar], _, 6),
     jarl:reply(Conn, -42, undefined, undefined, 6),
     ?receiveError(-42, null, 6),
+    send_jsonrpc_request(<<"baz">>, #{}, 7),
+    ?assertConnRequest(Conn, [baz], _, 7),
+    jarl:reply(Conn, internal_error, undefined, #{message => <<"Upsi">>}, 7),
+    ?assertMatch(#{error := #{code := -32603, message := <<"Internal error">>,
+                              data := #{message := <<"Upsi">>}},
+                   id := 7}, jarl_test_server:receive_jsonrpc_error()),
     ok.
 
 basic_client_synchronous_request_test(Config) ->

--- a/test/jarl_jsonrpc_SUITE.erl
+++ b/test/jarl_jsonrpc_SUITE.erl
@@ -128,15 +128,33 @@ preprocess_values(_) ->
     ?assertEqual(Term, jarl_jsonrpc:decode(Json)).
 
 error_data(_) ->
-    Term = {error, 123, <<"FooBar">>, <<"Some extra data">>, 42},
-    Json = <<"{\"id\":42,\"jsonrpc\":\"2.0\",\"error\":{\"code\":123,\"message\":\"FooBar\",\"data\":\"Some extra data\"}}">>,
-    ?assertMatch(Term, jarl_jsonrpc:decode(Json)),
-    Json2 = jarl_jsonrpc:encode(Term),
+    TermMap = {error, 123, <<"FooBar">>, #{details => <<"Some extra data">>}, 42},
+    JsonMap = <<"{\"id\":42,\"jsonrpc\":\"2.0\",\"error\":{\"code\":123,\"message\":\"FooBar\",\"data\":{\"details\":\"Some extra data\"}}}">>,
+    ?assertMatch(TermMap, jarl_jsonrpc:decode(JsonMap)),
+    Json2 = jarl_jsonrpc:encode(TermMap),
     ?assert(jsonrpc_check([<<"\"error\":{">>,
                            <<"\"id\":42">>,
                            <<"\"code\":123">>,
                            <<"\"message\":\"FooBar\"">>,
-                           <<"\"data\":\"Some extra data\"">>], Json2)).
+                           <<"\"data\":{\"details\":\"Some extra data\"}">>], Json2)),
+    TermList = {error, 456, <<"ListData">>, [1, true, #{k => <<"v">>}], 43},
+    Json3 = jarl_jsonrpc:encode(TermList),
+    ?assert(jsonrpc_check([<<"\"id\":43">>,
+                           <<"\"code\":456">>,
+                           <<"\"message\":\"ListData\"">>,
+                           <<"\"data\":[1,true,{\"k\":\"v\"}]">>], Json3)),
+    TermBin = {error, 789, <<"BinData">>, <<"primitive">>, 44},
+    Json4 = jarl_jsonrpc:encode(TermBin),
+    ?assert(jsonrpc_check([<<"\"id\":44">>,
+                           <<"\"code\":789">>,
+                           <<"\"message\":\"BinData\"">>,
+                           <<"\"data\":\"primitive\"">>], Json4)),
+    TermPrimitive = {error, 790, <<"PrimitiveData">>, 123, 45},
+    Json5 = jarl_jsonrpc:encode(TermPrimitive),
+    ?assert(jsonrpc_check([<<"\"id\":45">>,
+                           <<"\"code\":790">>,
+                           <<"\"message\":\"PrimitiveData\"">>,
+                           <<"\"data\":123">>], Json5)).
 
 omitted_params(_) ->
     Term1 = {request, <<"foo">>, undefined, 42},
@@ -167,7 +185,7 @@ encoding_error(_) ->
     ?assertException(error, {badarg, _}, jarl_jsonrpc:encode({result, <<"ok">>, undefined})),
     ?assertException(error, {badarg, _}, jarl_jsonrpc:encode({error, atom, undefined, undefined, 42})),
     ?assertException(error, {badarg, _}, jarl_jsonrpc:encode({error, 123, 456, undefined, 42})),
-    ?assertException(error, {badarg, _}, jarl_jsonrpc:encode({error, 123, undefined, 123, 42})),
+    ?assertException(error, {badarg, _}, jarl_jsonrpc:encode({error, 123, undefined, {'not', json}, 42})),
     ?assertException(error, {badarg, _}, jarl_jsonrpc:encode({error, 123, undefined, undefined, atom})),
     ok.
 


### PR DESCRIPTION
From the JSON-RPC specifications about the error data field:

> **data**
A Primitive or Structured value that contains additional information about the error.

The code did only accept binaries, see new tests.